### PR TITLE
Revert "Bump pillow from 8.1.1 to 8.2.0 in /docs"

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,4 @@ sphinx-copybutton==0.2.12
 recommonmark==0.6.0
 matplotlib==3.2.2
 ipython==7.15.0
-Pillow==8.2.0
+Pillow==8.1.1


### PR DESCRIPTION
Reverts ddaskan/trendypy#9